### PR TITLE
Avoid fallback when definition keys contain expressions

### DIFF
--- a/jjtemplate-compiler/src/main/java/io/github/sibmaks/jjtemplate/compiler/api/TemplateCompileOptions.java
+++ b/jjtemplate-compiler/src/main/java/io/github/sibmaks/jjtemplate/compiler/api/TemplateCompileOptions.java
@@ -41,6 +41,13 @@ public final class TemplateCompileOptions {
     @Builder.Default
     private final boolean optimize = true;
     /**
+     * When enabled, definition keys are parsed as expressions. If parsing fails,
+     * the compiler logs a warning and falls back to using the raw key string as
+     * a constant.
+     */
+    @Builder.Default
+    private final boolean definitionKeyExpressionFallback = false;
+    /**
      * Evaluation-specific configuration options,
      * such as locale and custom function behavior.
      * <p>

--- a/jjtemplate-compiler/src/main/java/io/github/sibmaks/jjtemplate/compiler/impl/TemplateCompilerImpl.java
+++ b/jjtemplate-compiler/src/main/java/io/github/sibmaks/jjtemplate/compiler/impl/TemplateCompilerImpl.java
@@ -55,7 +55,8 @@ public final class TemplateCompilerImpl implements TemplateCompiler {
         this.rootTemplateExpressionFactory = new RootTemplateExpressionFactory(
                 new TemplateTypeInferenceVisitor(),
                 expressionFactory,
-                expressionParser
+                expressionParser,
+                options.isDefinitionKeyExpressionFallback()
         );
         this.optimizers = new ArrayList<>();
         if (options.isOptimize()) {
@@ -122,7 +123,7 @@ public final class TemplateCompilerImpl implements TemplateCompiler {
 
     private ObjectTemplateExpression compileInternalVariable(Definition definition) {
         try {
-            return rootTemplateExpressionFactory.compileObject(definition);
+            return rootTemplateExpressionFactory.compileDefinitionObject(definition);
         } catch (Exception e) {
             throw new TemplateCompilationException("Error compiling definition", e);
         }

--- a/jjtemplate-compiler/src/test/java/io/github/sibmaks/jjtemplate/compiler/TemplateCompilerImplIntegrationTest.java
+++ b/jjtemplate-compiler/src/test/java/io/github/sibmaks/jjtemplate/compiler/TemplateCompilerImplIntegrationTest.java
@@ -237,10 +237,19 @@ class TemplateCompilerImplIntegrationTest {
                 .template(templateScript.getTemplate())
                 .definitions(modifiedDefinitions)
                 .build();
+        var begin = System.nanoTime();
         var compiled = compiler.compile(modifiedTemplateScript);
+        var compiledAt = System.nanoTime();
         var rendered = compiled.render(context);
+        var renderedAt = System.nanoTime();
         var renderedJson = OBJECT_MAPPER.convertValue(rendered, Object.class);
         assertEquals(excepted, renderedJson);
+        System.out.printf(
+                "Case '%s', compiled: %.4f ms, rendered: %.4f ms%n",
+                caseName,
+                (compiledAt - begin) / 1000000.0,
+                (renderedAt - compiledAt) / 1000000.0
+        );
     }
 
     @ParameterizedTest
@@ -255,10 +264,19 @@ class TemplateCompilerImplIntegrationTest {
                 .definitionKeyExpressionFallback(true)
                 .build();
         var compiler = TemplateCompiler.getInstance(options);
+        var begin = System.nanoTime();
         var compiled = compiler.compile(templateScript);
+        var compiledAt = System.nanoTime();
         var rendered = compiled.render(context);
+        var renderedAt = System.nanoTime();
         var renderedJson = OBJECT_MAPPER.convertValue(rendered, Object.class);
         assertEquals(excepted, renderedJson);
+        System.out.printf(
+                "Case '%s', compiled: %.4f ms, rendered: %.4f ms%n",
+                caseName,
+                (compiledAt - begin) / 1000000.0,
+                (renderedAt - compiledAt) / 1000000.0
+        );
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Motivation
- Allow definition-key fallback for plain string keys while preserving strict parsing for keys that look like expressions. 
- Prevent silent masking of real expression parse errors when a key already contains expression delimiters. 

### Description
- Added a `definitionKeyExpressionFallback` option to `TemplateCompileOptions` to enable opt-in fallback behavior for definition keys. 
- Wired `TemplateCompilerImpl` to pass the new option into `RootTemplateExpressionFactory` and added `compileDefinitionObject` to use the fallback-aware compile path. 
- Updated `RootTemplateExpressionFactory` to accept the fallback flag, changed `parseObjectKey` to accept an `allowFallback` boolean, and added `containsExpression` helper to skip fallback when a key contains `"{{"`. 
- When fallback is allowed and a key is a plain string, the code now logs a warning and uses a `ConstantTemplateExpression` for the raw key; expression-like keys will still surface parse errors. 

### Testing
- No automated tests were executed as part of this change. 
- Existing test suite was not run by this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c4dbadb88332a6f5241525570128)